### PR TITLE
Fix missing dist index html file

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "start:prod": "NODE_ENV=production node server/server.js",
     "docker:build": "docker build -t trade-unlock-pro .",
     "docker:build-prod": "docker build -f Dockerfile.prod -t trade-unlock-pro:prod .",
-    "docker:run": "docker run -p 3000:3000 --env-file .env trade-unlock-pro"
+    "docker:run": "docker run -p 3000:3000 --env-file .env trade-unlock-pro",
+    "prestart": "[ -d dist ] || npm run build",
+    "postinstall": "if [ \"$NODE_ENV\" = \"production\" ]; then npm run build; fi"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
Add `prestart` and `postinstall` scripts to `package.json` to ensure the frontend build is generated automatically in production environments.

The application was failing to deploy on Easypanel with `ENOENT: no such file or directory, stat '/code/dist/index.html'` because the `dist` directory, containing the built frontend assets, was not present at runtime. These scripts ensure `npm run build` is executed to create the `dist` folder before the server starts or during the `postinstall` phase in production.

---
<a href="https://cursor.com/background-agent?bcId=bc-12fbfe39-4351-4266-aa31-58c94376fd82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12fbfe39-4351-4266-aa31-58c94376fd82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

