### PR TITLE
Fix npm build and cache error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY package*.json ./
 
 # Install only production dependencies
 ENV NODE_ENV=production
-RUN npm ci --only=production && npm cache clean --force
+RUN npm ci --only=production --ignore-scripts
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -18,7 +18,7 @@ WORKDIR /app
 # Copy only production deps
 COPY package*.json ./
 ENV NODE_ENV=production
-RUN npm ci --only=production
+RUN npm ci --only=production --ignore-scripts
 
 # Copy dist and server
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
Add `--ignore-scripts` to production `npm ci` to prevent `postinstall` failures and remove unnecessary `npm cache clean`.

The `postinstall` script in `package.json` was attempting to run during the `npm ci --only=production` step. This script likely relies on development dependencies (e.g., build tools like Vite) that are not installed in the production-only layer, leading to an `exit code 127` error. By adding `--ignore-scripts`, we prevent these lifecycle scripts from executing during the production dependency installation, resolving the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2eda178-ed89-4910-b72c-cbcf4e8f1a3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2eda178-ed89-4910-b72c-cbcf4e8f1a3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

